### PR TITLE
BUGFIX: Allow users to log in

### DIFF
--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -61,7 +61,7 @@ defmodule Hexpm.Accounts.Auth do
 
     valid_user = user && !User.organization?(user) && user.password
 
-    if valid_user && password == user.password do
+    if valid_user && Bcrypt.verify_pass(password, user.password) do
       {:ok,
        %{
          key: nil,


### PR DESCRIPTION
## Problem

Users are not able to log into the site. When they attempt, they get the error
> Invalid username, email or password.

This error corresponds to an incorrect password being supplied.

## Solution

I discovered that we were comparing the password supplied by the website visitor to the _hashed_ password for a corresponding user record. Naturally, the hashed and unhashed version of the password did not pass an equality (`==`) test. Instead, the `bcrypt_elixir` library provides a `Bcrypt.verify_pass/2` function to compare unhashed passwords to their BCrypt hashes.